### PR TITLE
Style: put common functions in a separate file and header.

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -1,0 +1,18 @@
+#include "plugin.hpp"
+#include "Common.hpp"
+
+float clip(const float x) {
+	// We consider input is [-10.f;10.f] bounded. Reducing it to [-1.f;1.f]
+	const float y = x / 10.f;
+	// Pade approximant of x/(1 + x^12)^(1/12)
+	const float limit = 1.16691853009184f;
+	const float clamped = clamp(y, -limit, limit);
+
+	return ((clamped + 1.45833f * std::pow(clamped, 13) + 0.559028f * std::pow(clamped, 25) + 0.0427035f * std::pow(clamped, 37))
+		/ (1 + 1.54167f * std::pow(clamped, 12) + 0.642361f * std::pow(clamped, 24) + 0.0579909f * std::pow(clamped, 36))) * 10.f;
+}
+
+float exponentialBipolar80Pade_5_4(const float x) {
+	return (0.109568f * x + 0.281588f * std::pow(x, 3) + 0.133841f * std::pow(x, 5))
+		/ (1 - 0.630374f * std::pow(x, 2) + 0.166271f * std::pow(x, 4));
+}

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+// clip creates musical cliping on an input.
+// It comes from Befaco AxB+C VCV implementation (see README.md).
+float clip(const float x);
+
+// exponentialBipolar80Pade_5_4 transforms a linear -1.f to 1.f value (typically the value of a pot) to an exponential curve one.
+// It comes from Befaco AxB+C VCV implementation (see README.md).
+float exponentialBipolar80Pade_5_4(const float x);

--- a/src/VCDualNeuron.cpp
+++ b/src/VCDualNeuron.cpp
@@ -1,19 +1,5 @@
 #include "plugin.hpp"
-
-inline float clip(float x) {
-	x /= 10.f;
-	// Pade approximant of x/(1 + x^12)^(1/12)
-	const float limit = 1.16691853009184f;
-	x = clamp(x, -limit, limit);
-	return ((x + 1.45833f * std::pow(x, 13) + 0.559028f * std::pow(x, 25) + 0.0427035f * std::pow(x, 37))
-		/ (1 + 1.54167f * std::pow(x, 12) + 0.642361f * std::pow(x, 24) + 0.0579909f * std::pow(x, 36))) * 10.f;
-}
-
-inline float exponentialBipolar80Pade_5_4(float x) {
-	return (0.109568f * x + 0.281588f * std::pow(x, 3) + 0.133841f * std::pow(x, 5))
-		/ (1 - 0.630374f * std::pow(x, 2) + 0.166271f * std::pow(x, 4));
-}
-
+#include "Common.hpp"
 
 struct VCDualNeuron : Module {
 	enum ParamIds {


### PR DESCRIPTION
Ensuring access to `clip` and `exponentialBipolar80Pade_5_4` from anywhere including `Common.hpp` header.

Referencing the origin of those two functions (VCV Befaco AxB+C implementation)