### PR TITLE
Performances: Reimplement clip and exponential functions

### DIFF
--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -1,18 +1,20 @@
 #include "plugin.hpp"
 #include "Common.hpp"
 
-float clip(const float x) {
-	// We consider input is [-10.f;10.f] bounded. Reducing it to [-1.f;1.f]
-	const float y = x / 10.f;
-	// Pade approximant of x/(1 + x^12)^(1/12)
-	const float limit = 1.16691853009184f;
-	const float clamped = clamp(y, -limit, limit);
-
-	return ((clamped + 1.45833f * std::pow(clamped, 13) + 0.559028f * std::pow(clamped, 25) + 0.0427035f * std::pow(clamped, 37))
-		/ (1 + 1.54167f * std::pow(clamped, 12) + 0.642361f * std::pow(clamped, 24) + 0.0579909f * std::pow(clamped, 36))) * 10.f;
+float clipSignal(const float signal, const float ratio) { // ratio = 10/67
+	return clip(signal/10.f, ratio)*10.f;
 }
 
-float exponentialBipolar80Pade_5_4(const float x) {
-	return (0.109568f * x + 0.281588f * std::pow(x, 3) + 0.133841f * std::pow(x, 5))
-		/ (1 - 0.630374f * std::pow(x, 2) + 0.166271f * std::pow(x, 4));
+float clip(const float x, const float ratio) {
+	const float clamped = rack::math::clamp(x, -1.2f, 1.2f);
+	return clamped - clamped*clamped*clamped * ratio;
+}
+
+float expSignal(const float signal, const float ratio) {
+	return exponent(signal/10.f, ratio)*10.f;
+}
+
+float exponent(const float x, const float ratio) {
+	const float clamped = rack::math::clamp(x, -1.17f, 1.17f);
+	return clamped*clamped*clamped * ratio;
 }

--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
-// clip creates musical cliping on an input.
-// It comes from Befaco AxB+C VCV implementation (see README.md).
-float clip(const float x);
+// clip creates musical cliping on an input (range -1;1).
+// The higher the ratio, the higher the distortion.
+float clip(const float x, const float ratio);
 
-// exponentialBipolar80Pade_5_4 transforms a linear -1.f to 1.f value (typically the value of a pot) to an exponential curve one.
-// It comes from Befaco AxB+C VCV implementation (see README.md).
-float exponentialBipolar80Pade_5_4(const float x);
+// clipSignal creates musical cliping on a VCV signal (range -10;10).
+float clipSignal(const float signal, const float ratio = 0.14925373313f); // ratio = 10/67
+
+// exponent transforms a linear -1.f to 1.f value (typically the value of a pot) to an exponential curve one.
+// The higher the ratio, the stepper the curve.
+float exponent(const float x, const float ratio=0.39f);
+
+// expSignal transforms a VCV signal (range -10;10) to an exponential curve.
+float expSignal(const float signal, const float ratio=0.39f);

--- a/src/Diff.cpp
+++ b/src/Diff.cpp
@@ -1,4 +1,5 @@
 #include "plugin.hpp"
+#include "Common.hpp"
 
 
 struct Diff : Module {
@@ -52,14 +53,14 @@ struct Diff : Module {
 	}
 
 	void process(const ProcessArgs& args) override {
-		outputs[OUT1_OUTPUT].setVoltage(rack::math::clamp(inputs[IN1_INPUT].getNormalVoltage(0.f) - inputs[IN2_INPUT].getNormalVoltage(0.f) - inputs[IN3_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT2_OUTPUT].setVoltage(rack::math::clamp(inputs[IN4_INPUT].getNormalVoltage(0.f) - inputs[IN5_INPUT].getNormalVoltage(0.f) - inputs[IN6_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT3_OUTPUT].setVoltage(rack::math::clamp(inputs[IN7_INPUT].getNormalVoltage(0.f) - inputs[IN8_INPUT].getNormalVoltage(0.f) - inputs[IN9_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT4_OUTPUT].setVoltage(rack::math::clamp(inputs[IN10_INPUT].getNormalVoltage(0.f) - inputs[IN11_INPUT].getNormalVoltage(0.f) - inputs[IN12_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT5_OUTPUT].setVoltage(rack::math::clamp(inputs[IN13_INPUT].getNormalVoltage(0.f) - inputs[IN14_INPUT].getNormalVoltage(0.f) - inputs[IN15_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT6_OUTPUT].setVoltage(rack::math::clamp(inputs[IN16_INPUT].getNormalVoltage(0.f) - inputs[IN17_INPUT].getNormalVoltage(0.f) - inputs[IN18_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT7_OUTPUT].setVoltage(rack::math::clamp(inputs[IN19_INPUT].getNormalVoltage(0.f) - inputs[IN20_INPUT].getNormalVoltage(0.f) - inputs[IN21_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
-		outputs[OUT8_OUTPUT].setVoltage(rack::math::clamp(inputs[IN22_INPUT].getNormalVoltage(0.f) - inputs[IN23_INPUT].getNormalVoltage(0.f) - inputs[IN24_INPUT].getNormalVoltage(0.f),-10.f, 10.f));
+		outputs[OUT1_OUTPUT].setVoltage(clipSignal(inputs[IN1_INPUT].getNormalVoltage(0.f) - inputs[IN2_INPUT].getNormalVoltage(0.f) - inputs[IN3_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT2_OUTPUT].setVoltage(clipSignal(inputs[IN4_INPUT].getNormalVoltage(0.f) - inputs[IN5_INPUT].getNormalVoltage(0.f) - inputs[IN6_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT3_OUTPUT].setVoltage(clipSignal(inputs[IN7_INPUT].getNormalVoltage(0.f) - inputs[IN8_INPUT].getNormalVoltage(0.f) - inputs[IN9_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT4_OUTPUT].setVoltage(clipSignal(inputs[IN10_INPUT].getNormalVoltage(0.f) - inputs[IN11_INPUT].getNormalVoltage(0.f) - inputs[IN12_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT5_OUTPUT].setVoltage(clipSignal(inputs[IN13_INPUT].getNormalVoltage(0.f) - inputs[IN14_INPUT].getNormalVoltage(0.f) - inputs[IN15_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT6_OUTPUT].setVoltage(clipSignal(inputs[IN16_INPUT].getNormalVoltage(0.f) - inputs[IN17_INPUT].getNormalVoltage(0.f) - inputs[IN18_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT7_OUTPUT].setVoltage(clipSignal(inputs[IN19_INPUT].getNormalVoltage(0.f) - inputs[IN20_INPUT].getNormalVoltage(0.f) - inputs[IN21_INPUT].getNormalVoltage(0.f)));
+		outputs[OUT8_OUTPUT].setVoltage(clipSignal(inputs[IN22_INPUT].getNormalVoltage(0.f) - inputs[IN23_INPUT].getNormalVoltage(0.f) - inputs[IN24_INPUT].getNormalVoltage(0.f)));
 	}
 };
 

--- a/src/Multiplier.cpp
+++ b/src/Multiplier.cpp
@@ -62,14 +62,14 @@ struct Multiplier : Module {
 
 	void process(const ProcessArgs& args) override {
 		const float results[8] = {
-			inputs[SIGNAL1_INPUT].getNormalVoltage(0.f) * inputs[CARRIER1_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL1_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL2_INPUT].getNormalVoltage(0.f) * inputs[CARRIER2_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL2_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL3_INPUT].getNormalVoltage(0.f) * inputs[CARRIER3_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL3_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL4_INPUT].getNormalVoltage(0.f) * inputs[CARRIER4_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL4_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL5_INPUT].getNormalVoltage(0.f) * inputs[CARRIER5_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL5_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL6_INPUT].getNormalVoltage(0.f) * inputs[CARRIER6_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL6_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL7_INPUT].getNormalVoltage(0.f) * inputs[CARRIER7_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL7_PARAM].getValue()) / 5.f,
-			inputs[SIGNAL8_INPUT].getNormalVoltage(0.f) * inputs[CARRIER8_INPUT].getNormalVoltage(5.f) * 2.f * exponentialBipolar80Pade_5_4(params[CARRIER_LEVEL8_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL1_INPUT].getNormalVoltage(0.f) * inputs[CARRIER1_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL1_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL2_INPUT].getNormalVoltage(0.f) * inputs[CARRIER2_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL2_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL3_INPUT].getNormalVoltage(0.f) * inputs[CARRIER3_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL3_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL4_INPUT].getNormalVoltage(0.f) * inputs[CARRIER4_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL4_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL5_INPUT].getNormalVoltage(0.f) * inputs[CARRIER5_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL5_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL6_INPUT].getNormalVoltage(0.f) * inputs[CARRIER6_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL6_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL7_INPUT].getNormalVoltage(0.f) * inputs[CARRIER7_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL7_PARAM].getValue()) / 5.f,
+			inputs[SIGNAL8_INPUT].getNormalVoltage(0.f) * inputs[CARRIER8_INPUT].getNormalVoltage(5.f) * 2.f * exponent(params[CARRIER_LEVEL8_PARAM].getValue()) / 5.f,
 		};
 
 		const float out1 = results[0];
@@ -81,14 +81,14 @@ struct Multiplier : Module {
 		const float out7 = outputs[OUT6_OUTPUT].isConnected()? results[6]: results[6]+out6;
 		const float out8 = outputs[OUT7_OUTPUT].isConnected()? results[7]: results[7]+out7;
 
-		outputs[OUT1_OUTPUT].setVoltage(clip(out1));
-		outputs[OUT2_OUTPUT].setVoltage(clip(out2));
-		outputs[OUT3_OUTPUT].setVoltage(clip(out3));
-		outputs[OUT4_OUTPUT].setVoltage(clip(out4));
-		outputs[OUT5_OUTPUT].setVoltage(clip(out5));
-		outputs[OUT6_OUTPUT].setVoltage(clip(out6));
-		outputs[OUT7_OUTPUT].setVoltage(clip(out7));
-		outputs[OUT8_OUTPUT].setVoltage(clip(out8));
+		outputs[OUT1_OUTPUT].setVoltage(clipSignal(out1));
+		outputs[OUT2_OUTPUT].setVoltage(clipSignal(out2));
+		outputs[OUT3_OUTPUT].setVoltage(clipSignal(out3));
+		outputs[OUT4_OUTPUT].setVoltage(clipSignal(out4));
+		outputs[OUT5_OUTPUT].setVoltage(clipSignal(out5));
+		outputs[OUT6_OUTPUT].setVoltage(clipSignal(out6));
+		outputs[OUT7_OUTPUT].setVoltage(clipSignal(out7));
+		outputs[OUT8_OUTPUT].setVoltage(clipSignal(out8));
 	}
 };
 

--- a/src/Sum.cpp
+++ b/src/Sum.cpp
@@ -73,14 +73,14 @@ struct Sum : Module {
 		const float out7 = outputs[OUT6_OUTPUT].isConnected()? results[6]: results[6]+out6;
 		const float out8 = outputs[OUT7_OUTPUT].isConnected()? results[7]: results[7]+out7;
 
-		outputs[OUT1_OUTPUT].setVoltage(clip(out1));
-		outputs[OUT2_OUTPUT].setVoltage(clip(out2));
-		outputs[OUT3_OUTPUT].setVoltage(clip(out3));
-		outputs[OUT4_OUTPUT].setVoltage(clip(out4));
-		outputs[OUT5_OUTPUT].setVoltage(clip(out5));
-		outputs[OUT6_OUTPUT].setVoltage(clip(out6));
-		outputs[OUT7_OUTPUT].setVoltage(clip(out7));
-		outputs[OUT8_OUTPUT].setVoltage(clip(out8));
+		outputs[OUT1_OUTPUT].setVoltage(clipSignal(out1));
+		outputs[OUT2_OUTPUT].setVoltage(clipSignal(out2));
+		outputs[OUT3_OUTPUT].setVoltage(clipSignal(out3));
+		outputs[OUT4_OUTPUT].setVoltage(clipSignal(out4));
+		outputs[OUT5_OUTPUT].setVoltage(clipSignal(out5));
+		outputs[OUT6_OUTPUT].setVoltage(clipSignal(out6));
+		outputs[OUT7_OUTPUT].setVoltage(clipSignal(out7));
+		outputs[OUT8_OUTPUT].setVoltage(clipSignal(out8));
 	}
 };
 

--- a/src/VCDualNeuron.cpp
+++ b/src/VCDualNeuron.cpp
@@ -134,20 +134,20 @@ struct VCDualNeuron : Module {
 		// Neuron A
 		// Input 1
 		const float aSignal = inputs[A_SIGNAL_INPUT].getVoltage();
-		const float aCarrier = inputs[A_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[A_CARRIER_LEVEL_PARAM].getValue());
-		const float aOffset = inputs[A_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[A_OFFSET_LEVEL_PARAM].getValue());
+		const float aCarrier = inputs[A_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[A_CARRIER_LEVEL_PARAM].getValue());
+		const float aOffset = inputs[A_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[A_OFFSET_LEVEL_PARAM].getValue());
 		const float aInput = aSignal * aCarrier/5.f + aOffset;
 
 		// Input 2
 		const float bSignal = inputs[B_SIGNAL_INPUT].getVoltage();
-		const float bCarrier = inputs[B_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[B_CARRIER_LEVEL_PARAM].getValue());
-		const float bOffset = inputs[B_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[B_OFFSET_LEVEL_PARAM].getValue());
+		const float bCarrier = inputs[B_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[B_CARRIER_LEVEL_PARAM].getValue());
+		const float bOffset = inputs[B_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[B_OFFSET_LEVEL_PARAM].getValue());
 		const float bInput = bSignal * bCarrier/5.f + bOffset;
 
 		// Input 3
 		const float cSignal = inputs[C_SIGNAL_INPUT].getVoltage();
-		const float cCarrier = inputs[C_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[C_CARRIER_LEVEL_PARAM].getValue());
-		const float cOffset = inputs[C_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[C_OFFSET_LEVEL_PARAM].getValue());
+		const float cCarrier = inputs[C_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[C_CARRIER_LEVEL_PARAM].getValue());
+		const float cOffset = inputs[C_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[C_OFFSET_LEVEL_PARAM].getValue());
 		const float cInput = cSignal * cCarrier/5.f + cOffset;
 
 		// Params
@@ -162,20 +162,20 @@ struct VCDualNeuron : Module {
 		// Neuron B
 		// Input 1
 		const float dSignal = inputs[D_SIGNAL_INPUT].getVoltage();
-		const float dCarrier = inputs[D_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[D_CARRIER_LEVEL_PARAM].getValue());
-		const float dOffset = inputs[D_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[D_OFFSET_LEVEL_PARAM].getValue());
+		const float dCarrier = inputs[D_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[D_CARRIER_LEVEL_PARAM].getValue());
+		const float dOffset = inputs[D_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[D_OFFSET_LEVEL_PARAM].getValue());
 		const float dInput = dSignal * dCarrier/5.f + dOffset;
 
 		// Input 2
 		const float eSignal = inputs[E_SIGNAL_INPUT].getVoltage();
-		const float eCarrier = inputs[E_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[E_CARRIER_LEVEL_PARAM].getValue());
-		const float eOffset = inputs[E_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[E_OFFSET_LEVEL_PARAM].getValue());
+		const float eCarrier = inputs[E_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[E_CARRIER_LEVEL_PARAM].getValue());
+		const float eOffset = inputs[E_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[E_OFFSET_LEVEL_PARAM].getValue());
 		const float eInput = eSignal * eCarrier/5.f + eOffset;
 
 		// Input 3
 		const float fSignal = inputs[F_SIGNAL_INPUT].getVoltage();
-		const float fCarrier = inputs[F_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[F_CARRIER_LEVEL_PARAM].getValue());
-		const float fOffset = inputs[F_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[F_OFFSET_LEVEL_PARAM].getValue());
+		const float fCarrier = inputs[F_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[F_CARRIER_LEVEL_PARAM].getValue());
+		const float fOffset = inputs[F_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[F_OFFSET_LEVEL_PARAM].getValue());
 		const float fInput = fSignal * fCarrier/5.f + fOffset;
 
 		// Params
@@ -190,14 +190,14 @@ struct VCDualNeuron : Module {
 		// Combiner
 		// Input 1
 		const float gSignal = inputs[G_SIGNAL_INPUT].getNormalVoltage(aOutput);
-		const float gCarrier = inputs[G_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[G_CARRIER_LEVEL_PARAM].getValue());
-		const float gOffset = inputs[G_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[G_OFFSET_LEVEL_PARAM].getValue());
+		const float gCarrier = inputs[G_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[G_CARRIER_LEVEL_PARAM].getValue());
+		const float gOffset = inputs[G_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[G_OFFSET_LEVEL_PARAM].getValue());
 		const float gInput = gSignal * gCarrier/5.f + gOffset;
 
 		// Input 2
 		const float hSignal = inputs[H_SIGNAL_INPUT].getNormalVoltage(bOutput);
-		const float hCarrier = inputs[H_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[H_CARRIER_LEVEL_PARAM].getValue());
-		const float hOffset = inputs[H_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponentialBipolar80Pade_5_4(params[H_OFFSET_LEVEL_PARAM].getValue());
+		const float hCarrier = inputs[H_CARRIER_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[H_CARRIER_LEVEL_PARAM].getValue());
+		const float hOffset = inputs[H_OFFSET_INPUT].getNormalVoltage(5.f) * 2.f*exponent(params[H_OFFSET_LEVEL_PARAM].getValue());
 		const float hInput = hSignal * hCarrier/5.f + hOffset;
 
 		// Outputs
@@ -211,18 +211,18 @@ struct VCDualNeuron : Module {
 
 		// Set outpus
 		// Neuron A
-		outputs[A_OUTPUT_OUTPUT].setVoltage(clip(aOutput));
+		outputs[A_OUTPUT_OUTPUT].setVoltage(clipSignal(aOutput));
 
 		// Neuron B
-		outputs[B_OUTPUT_OUTPUT].setVoltage(clip(bOutput));
+		outputs[B_OUTPUT_OUTPUT].setVoltage(clipSignal(bOutput));
 		
 		// Combiner
-		outputs[DIFFRECT_POS_OUTPUT].setVoltage(clip(diffrectPos));
-		outputs[DIFFRECT_NEG_OUTPUT].setVoltage(clip(diffrectNeg));
-		outputs[MAX_OUTPUT].setVoltage(clip(max));
-		outputs[MIN_OUTPUT].setVoltage(clip(min));
-		outputs[SUM_OUTPUT].setVoltage(clip(sum));
-		outputs[INV_OUTPUT].setVoltage(clip(inv));
+		outputs[DIFFRECT_POS_OUTPUT].setVoltage(clipSignal(diffrectPos));
+		outputs[DIFFRECT_NEG_OUTPUT].setVoltage(clipSignal(diffrectNeg));
+		outputs[MAX_OUTPUT].setVoltage(clipSignal(max));
+		outputs[MIN_OUTPUT].setVoltage(clipSignal(min));
+		outputs[SUM_OUTPUT].setVoltage(clipSignal(sum));
+		outputs[INV_OUTPUT].setVoltage(clipSignal(inv));
 	}
 };
 


### PR DESCRIPTION
## Problem

The modules that use `clip` and `exponentialBipolar80Pade_5_4` functions experience huge performance issues due to the high-order polynomial calculations made in those functions. For instance, VC Dual Neuron can consume up to 18% CPU on my machine.

## Solution

We re-implement those two functions with simpler approximations:

* clip becomes

![clip formula](https://render.githubusercontent.com/render/math?math=f(x)=x\-x^{3}/6.7)

* exponent becomes

![exponent formula](https://render.githubusercontent.com/render/math?math=f(x)\=x^{3}\cdot0.39)

The new CPU usages are down to less than 2% on all modules.