### PR TITLE
Revert "Performance: Use -ffast-math on compile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ RACK_DIR ?= ../..
 # FLAGS will be passed to both the C and C++ compiler
 FLAGS +=
 CFLAGS +=
-CXXFLAGS += -ffast-math
+CXXFLAGS +=
 
 # Careful about linking to shared libraries, since you can't assume much about the user's environment and library search path.
 # Static libraries are fine, but they should be added to this plugin's build system.


### PR DESCRIPTION
This reverts commit 5dda43f15e4028142223002dd66e56a9086020f8.

https://github.com/VCVRack/library/issues/667#issuecomment-744527207

> https://github.com/denischevalier/StalysVCVPlugin/blob/main/Makefile#L7 breaks a lot of stuff like std::isfinite(). I'm not sure why it's needed since -funsafe-math-optimizations should cover most reasonable floating point optimization. If it's needed in DSP code, you could add the optimization on a per-function basis with __attribute__((optimize("-ffast-math"))). But I can't think of a reason why that would improve your code's speed that much.